### PR TITLE
[PoC] Snapshot to bintrie

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/trie"
+	"github.com/syndtr/goleveldb/leveldb"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -669,6 +670,18 @@ func snapToBin(ctx *cli.Context) error {
 	log.Info("Generating binary trie", "root", root)
 	generatedRoot := snapshot.GenerateBinaryTree(ctx.GlobalString(utils.DataDirFlag.Name), it)
 	log.Info("Generation done", "root", root, "binary root", generatedRoot)
+
+	db, err := leveldb.OpenFile(ctx.GlobalString(utils.DataDirFlag.Name)+"/bintrie", nil)
+	it, _ = snapTree.AccountIterator(root, common.Hash{})
+	found := 0
+	total := 0
+	for it.Next() {
+		if trie.CheckKey(db, it.Hash().Bytes(), generatedRoot[:], 0, it.Account()) {
+			found++
+		}
+	}
+	log.Info("Read check finished", "total", total, "found", found)
+	db.Close()
 	return nil
 }
 

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -218,6 +218,22 @@ Use "ethereum dump 0" to dump the genesis block.`,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 	}
+	generateBinaryTrieCommand = cli.Command{
+		Action:    utils.MigrateFlags(snapToBin),
+		Name:      "bintrie",
+		Usage:     "Convert the snapshot DB to a binary trie",
+		ArgsUsage: " ",
+		Flags: []cli.Flag{
+			utils.DataDirFlag,
+			utils.AncientFlag,
+			utils.CacheFlag,
+			utils.TestnetFlag,
+			utils.RinkebyFlag,
+			utils.GoerliFlag,
+			utils.SyncModeFlag,
+		},
+		Category: "BLOCKCHAIN COMMANDS",
+	}
 )
 
 // initGenesis will initialise the given JSON format genesis file and writes it as
@@ -624,6 +640,35 @@ func snapToHash(ctx *cli.Context) error {
 		return fmt.Errorf("Wrong hash generated, expected %x, got %x", root, generatedRoot[:])
 	}
 	log.Info("Generation done", "root", generatedRoot)
+	return nil
+}
+
+func snapToBin(ctx *cli.Context) error {
+	node, _ := makeConfigNode(ctx)
+	chain, chainDb := utils.MakeChain(ctx, node)
+
+	defer func() {
+		node.Close()
+		chain.Stop()
+		chainDb.Close()
+	}()
+
+	snapTree := chain.Snapshot()
+	if snapTree == nil {
+		return fmt.Errorf("No snapshot tree available")
+	}
+	block := chain.CurrentBlock()
+	if block == nil {
+		return fmt.Errorf("no blocks present")
+	}
+	root := block.Root()
+	it, err := snapTree.AccountIterator(root, common.Hash{})
+	if err != nil {
+		return fmt.Errorf("Could not create iterator for root %x: %v", root, err)
+	}
+	log.Info("Generating binary trie", "root", root)
+	generatedRoot := snapshot.GenerateBinaryTree(it)
+	log.Info("Generation done", "root", root, "binary root", generatedRoot)
 	return nil
 }
 

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -676,6 +676,7 @@ func snapToBin(ctx *cli.Context) error {
 	found := 0
 	total := 0
 	for it.Next() {
+		total++
 		if trie.CheckKey(db, it.Hash().Bytes(), generatedRoot[:], 0, it.Account()) {
 			found++
 		}

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -667,7 +667,7 @@ func snapToBin(ctx *cli.Context) error {
 		return fmt.Errorf("Could not create iterator for root %x: %v", root, err)
 	}
 	log.Info("Generating binary trie", "root", root)
-	generatedRoot := snapshot.GenerateBinaryTree(it)
+	generatedRoot := snapshot.GenerateBinaryTree(ctx.GlobalString(utils.DataDirFlag.Name), it)
 	log.Info("Generation done", "root", root, "binary root", generatedRoot)
 	return nil
 }

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -19,7 +19,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -33,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/event"

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -211,6 +211,7 @@ func init() {
 		dumpGenesisCommand,
 		inspectCommand,
 		generateTrieCommand,
+		generateBinaryTrieCommand,
 		// See accountcmd.go:
 		accountCommand,
 		walletCommand,

--- a/core/state/snapshot/hextrie_generator.go
+++ b/core/state/snapshot/hextrie_generator.go
@@ -40,10 +40,8 @@ func GenerateBinaryTree(it AccountIterator) common.Hash {
 	if err != nil {
 		panic(fmt.Sprintf("error opening bintrie db, err=%v", err))
 	}
-	btrie, err := trie.NewBinary(true)
-	if err != nil {
-		panic(fmt.Sprintf("error creating binary trie, err=%v", err))
-	}
+	btrie := new(trie.BinaryTrie)
+	btrie.CommitCh = make(chan trie.BinaryHashPreimage)
 
 	var nodeCount uint64
 	var wg sync.WaitGroup

--- a/core/state/snapshot/hextrie_generator.go
+++ b/core/state/snapshot/hextrie_generator.go
@@ -53,12 +53,12 @@ func GenerateBinaryTree(it AccountIterator) common.Hash {
 	}
 	log.Info("Inserted all leaves", "count", counter)
 
-	h, err := btrie.Commit()
+	err = btrie.Commit()
 	if err != nil {
 		panic(fmt.Sprintf("error committing trie, err=%v", err))
 	}
 
-	return common.BytesToHash(h)
+	return common.Hash{}
 }
 
 // GenerateTrieRoot takes an account iterator and reproduces the root hash.

--- a/core/state/snapshot/hextrie_generator.go
+++ b/core/state/snapshot/hextrie_generator.go
@@ -51,7 +51,7 @@ func GenerateBinaryTree(path string, it AccountIterator) common.Hash {
 		defer wg.Done()
 		for kv := range btrie.CommitCh {
 			nodeCount++
-			log.Info("inserting key", "count", nodeCount, "key", common.ToHex(kv.Key), "value", common.ToHex(kv.Value))
+			log.Debug("inserting key", "count", nodeCount, "key", common.ToHex(kv.Key), "value", common.ToHex(kv.Value))
 			db.Put(kv.Key, kv.Value, nil)
 		}
 	}()

--- a/core/state/snapshot/hextrie_generator.go
+++ b/core/state/snapshot/hextrie_generator.go
@@ -35,8 +35,8 @@ type leaf struct {
 
 type trieGeneratorFn func(in chan (leaf), out chan (common.Hash))
 
-func GenerateBinaryTree(it AccountIterator) common.Hash {
-	db, err := rawdb.NewLevelDBDatabase("./bintrie", 128, 1024, "")
+func GenerateBinaryTree(path string, it AccountIterator) common.Hash {
+	db, err := rawdb.NewLevelDBDatabase(path+"/bintrie", 128, 1024, "")
 	if err != nil {
 		panic(fmt.Sprintf("error opening bintrie db, err=%v", err))
 	}

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d h1:gZZadD8H+fF+n9CmNhYL1Y0dJB+kLOmKd7FbPJLeGHs=
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef h1:wHSqTBrZW24CsNJDfeh9Ex6Pm0Rcpc7qrgKBiL44vF4=

--- a/trie/binary.go
+++ b/trie/binary.go
@@ -48,23 +48,27 @@ type (
 	// BinaryTrie is a node with two children ("left" and "right")
 	// It can be prefixed by bits that are common to all subtrie
 	// keys and it can also hold a value.
-	BinaryTrie struct {
+	binBranchNode struct {
 		left  binaryNode
 		right binaryNode
+
+		// "Extension" part: a pointer to the leaf, as well as a
+		// start offset into the key and its length.
+		leafPtr   *binLeafNode
+		startBit  int
+		prefixLen int
+	}
+
+	binLeafNode struct {
+		key   []byte
 		value []byte
 
 		// Used to send (hash, preimage) pairs when hashing
 		CommitCh chan BinaryHashPreimage
 
-		// This is the binary equivalent of "extension nodes":
-		// binary nodes can have a prefix that is common to all
-		// subtrees. The prefix is defined by a series of bytes,
-		// and two offsets marking the start bit and the end bit
-		// of the range.
-		prefix   []byte
 		startBit int
-		endBit   int // Technically, this is the "1st bit past the end"
 	}
+
 	hashBinaryNode []byte
 )
 

--- a/trie/binary.go
+++ b/trie/binary.go
@@ -120,7 +120,7 @@ func (t *BinaryTrie) tryGet(key []byte, depth int) ([]byte, error) {
 
 	if child == nil {
 		if depth+i < len(key)*8-1 || t.value == nil {
-			return nil, fmt.Errorf("could not find key 0x%s in trie %v %v %v", common.ToHex(key), depth+i, len(key), t.value)
+			return nil, fmt.Errorf("could not find key %s in trie depth=%d keylen=%d value=%v", common.ToHex(key), depth+i, len(key), t.value)
 		}
 		return t.value, nil
 	}

--- a/trie/binary.go
+++ b/trie/binary.go
@@ -321,6 +321,7 @@ func (t *BinaryTrie) insert(depth int, key, value []byte, hashLeft bool) error {
 			oldChild.endBit = t.endBit
 			oldChild.left = t.left
 			oldChild.right = t.right
+			oldChild.value = t.value
 			oldChild.CommitCh = t.CommitCh
 
 			// Create the child3 part
@@ -352,6 +353,7 @@ func (t *BinaryTrie) insert(depth int, key, value []byte, hashLeft bool) error {
 				}
 				t.right = newChild
 			}
+			t.value = nil
 
 			return nil
 		}

--- a/trie/binary.go
+++ b/trie/binary.go
@@ -213,7 +213,11 @@ func CheckKey(db *leveldb.DB, key, root []byte, depth int, value []byte) bool {
 		}
 	}
 
-	return true // bytes.Equal(out.Value, value)
+	if !bytes.Equal(out.Value, value) {
+		log.Error("invalid value found", "got", out.Value, "expected", value, "fulldepth", fulldepth, "depth", depth, "key", key)
+		return false
+	}
+	return true
 }
 
 // Hash calculates the hash of an expanded (i.e. not already
@@ -281,7 +285,8 @@ func (t *BinaryTrie) insert(depth int, key, value []byte, hashLeft bool) error {
 	// Special case: the trie is empty
 	if depth == 0 && t.left == nil && t.right == nil && len(t.prefix) == 0 {
 		t.prefix = key
-		t.value = value
+		t.value = make([]byte, len(value))
+		copy(t.value, value)
 		t.startBit = 0
 		t.endBit = 8 * len(key)
 		return nil
@@ -329,7 +334,8 @@ func (t *BinaryTrie) insert(depth int, key, value []byte, hashLeft bool) error {
 			newChild.prefix = key
 			newChild.startBit = depth + i + 1
 			newChild.endBit = len(key) * 8
-			newChild.value = value
+			newChild.value = make([]byte, len(value))
+			copy(newChild.value, value)
 			newChild.CommitCh = t.CommitCh
 
 			// reconfigure the [ a b ] part by just specifying

--- a/trie/binary.go
+++ b/trie/binary.go
@@ -71,7 +71,7 @@ func (t *BinaryTrie) tryGet(key []byte, depth int) ([]byte, error) {
 			}
 			return t.value, nil
 		}
-		return t.left.tryGet(key, depth+1)
+		return t.right.tryGet(key, depth+1)
 	}
 }
 

--- a/trie/binary.go
+++ b/trie/binary.go
@@ -164,7 +164,7 @@ func (t *BinaryTrie) bitPrefix() []byte {
 		}
 	}
 	if t.getPrefixLen() > 0 {
-		bp[0] = byte(t.endBit-t.startBit) / 8
+		bp[0] = byte(t.endBit-t.startBit) % 8
 	}
 
 	return bp

--- a/trie/binary.go
+++ b/trie/binary.go
@@ -67,7 +67,7 @@ func (t *BinaryTrie) tryGet(key []byte, depth int) ([]byte, error) {
 	} else {
 		if t.right == nil {
 			if depth < len(key)*8-1 || t.value == nil {
-				return nil, fmt.Errorf("could not find key %s in trie", common.ToHex(key))
+				return nil, fmt.Errorf("could not find key 0x%x in trie", key)
 			}
 			return t.value, nil
 		}

--- a/trie/binary.go
+++ b/trie/binary.go
@@ -1,0 +1,154 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"golang.org/x/crypto/sha3"
+)
+
+type BinaryTrie struct {
+	left  *BinaryTrie
+	right *BinaryTrie
+	value []byte
+	db    ethdb.Database
+}
+
+func NewBinary(db ethdb.Database) (*BinaryTrie, error) {
+	if db == nil {
+		return nil, fmt.Errorf("trie.NewBinary called without a database")
+	}
+
+	return &BinaryTrie{db: db}, nil
+}
+
+func (t *BinaryTrie) Get(key []byte) []byte {
+	res, err := t.TryGet(key)
+	if err != nil {
+		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
+	}
+	return res
+}
+
+func (t *BinaryTrie) TryGet(key []byte) ([]byte, error) {
+	value, err := t.tryGet(key, 0)
+	return value, err
+}
+
+func (t *BinaryTrie) tryGet(key []byte, depth int) ([]byte, error) {
+	by := key[depth/8]
+	bi := (by >> uint(depth%8)) & 1
+	if bi == 0 {
+		if t.left == nil {
+			if depth < len(key)*8-1 || t.value == nil {
+				return nil, fmt.Errorf("could not find key %s in trie", common.ToHex(key))
+			}
+			return t.value, nil
+		}
+		return t.left.tryGet(key, depth+1)
+	} else {
+		if t.right == nil {
+			if depth < len(key)*8-1 || t.value == nil {
+				return nil, fmt.Errorf("could not find key %s in trie", common.ToHex(key))
+			}
+			return t.value, nil
+		}
+		return t.left.tryGet(key, depth+1)
+	}
+}
+
+func (t *BinaryTrie) Update(key, value []byte) {
+	if err := t.TryUpdate(key, value); err != nil {
+		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
+	}
+}
+
+func (t *BinaryTrie) TryUpdate(key, value []byte) error {
+	// TODO check key depth
+	err := t.insert(0, key, value)
+	return err
+}
+
+func (t *BinaryTrie) insert(depth int, key, value []byte) error {
+	// TODO hash intermediate nodes
+	by := key[depth/8]
+	bi := (by >> uint(depth%8)) & 1
+	if bi == 0 {
+		if t.left == nil {
+			if depth == len(key)*8-2 {
+				t.left = &BinaryTrie{nil, nil, value, t.db}
+				return nil
+			} else {
+				t.left = &BinaryTrie{nil, nil, nil, t.db}
+			}
+		}
+		return t.left.insert(depth+1, key, value)
+	} else {
+		if t.right == nil {
+			if depth == len(key)*8-2 {
+				t.right = &BinaryTrie{nil, nil, value, t.db}
+				return nil
+			} else {
+				t.right = &BinaryTrie{nil, nil, nil, t.db}
+			}
+		}
+		return t.right.insert(depth+1, key, value)
+	}
+}
+
+func (t *BinaryTrie) Commit() ([]byte, error) {
+	var payload [3][]byte
+	var err error
+	if t.left != nil {
+		payload[0], err = t.left.Commit()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if t.right != nil {
+		payload[1], err = t.right.Commit()
+		if err != nil {
+			return nil, err
+		}
+	}
+	hasher := sha3.NewLegacyKeccak256()
+	if t.value != nil {
+		hasher.Write(t.value)
+		hasher.Sum(payload[2][:])
+	}
+
+	hasher.Reset()
+	hasher.Write(payload[0])
+	hasher.Write(payload[1])
+	hasher.Write(payload[2])
+	h := hasher.Sum(nil)
+	data := make([]byte, len(payload[0])+len(payload[1])+len(payload[2])+3)
+	data[0] = byte(len(payload[0]))
+	copy(data[1:], payload[0])
+	data[len(payload[0])+1] = byte(len(payload[1]))
+	copy(data[2+len(payload[0]):], payload[1])
+	data[len(payload[0])+len(payload[1])+2] = byte(len(payload[2]))
+	copy(data[2+len(payload[0])+len(payload[1]):], payload[2])
+
+	t.db.Put(h, data)
+
+	return h, err
+}

--- a/trie/binary_test.go
+++ b/trie/binary_test.go
@@ -82,15 +82,13 @@ func TestBinaryForkInsertRead(t *testing.T) {
 		}
 	}
 
-	for i := byte(0); i < 10; i++ {
-		v, err := trie.TryGet([]byte{i})
-		if err != nil {
-			t.Fatalf("could not read data back from simple binary trie, err=%v", err)
-		}
+	v, err := trie.TryGet([]byte{9})
+	if err != nil {
+		t.Fatalf("could not read data back from simple binary trie, err=%v", err)
+	}
 
-		if !bytes.Equal(v, common.FromHex("01")) {
-			t.Fatalf("Invalid value read from the binary trie: %s != %s", common.ToHex(v), "01")
-		}
+	if !bytes.Equal(v, common.FromHex("01")) {
+		t.Fatalf("Invalid value read from the binary trie: %s != %s", common.ToHex(v), "01")
 	}
 
 }

--- a/trie/binary_test.go
+++ b/trie/binary_test.go
@@ -95,3 +95,47 @@ func TestBinaryForkInsertRead(t *testing.T) {
 	}
 
 }
+
+func TestBinaryInsertLeftRight(t *testing.T) {
+	trie, err := NewBinary(nil)
+	if err != nil {
+		t.Fatalf("error creating binary trie: %v", err)
+	}
+
+	trie.TryUpdate([]byte{0}, []byte{0})
+	trie.TryUpdate([]byte{128}, []byte{1})
+
+	// Trie is expected to look like this:
+	//         /\
+	//        / /
+	//       / /
+	//      / /
+	//     / /
+	//    / /
+	//   / /
+	//  / /
+
+	// Check there is a left branch
+	if trie.left == nil {
+		t.Fatal("empty left branch")
+	}
+
+	// Check that the left branch has already been hashed
+	if _, ok := trie.left.(hashBinaryNode); !ok {
+		t.Fatalf("left branch should have been hashed!")
+	}
+
+	// Check there is a right branch
+	if trie.right == nil {
+		t.Fatal("empty right branch")
+	}
+
+	// Check that the right branch has only lefts after the
+	// first right.
+	for i, tr := 1, trie.right; i < 8; i++ {
+		if tr == nil {
+			t.Fatal("invalid trie structure")
+		}
+		tr = tr.(*BinaryTrie).left
+	}
+}

--- a/trie/binary_test.go
+++ b/trie/binary_test.go
@@ -1,0 +1,97 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb/memorydb"
+)
+
+func TestBinaryLeafReadEmpty(t *testing.T) {
+	trie, err := NewBinary(NewDatabase(memorydb.New()))
+	if err != nil {
+		t.Fatalf("error creating binary trie: %v", err)
+	}
+
+	_, err = trie.TryGet(common.FromHex("00"))
+	if err == nil {
+		t.Fatalf("should have returned an error trying to get from an empty binry trie, err=%v", err)
+	}
+}
+
+func TestBinaryLeafInsert(t *testing.T) {
+	trie, err := NewBinary(NewDatabase(memorydb.New()))
+	if err != nil {
+		t.Fatalf("error creating binary trie: %v", err)
+	}
+
+	err = trie.TryUpdate(common.FromHex("00"), common.FromHex("00"))
+	if err != nil {
+		t.Fatalf("could not insert (0x00, 0x00) into an empty binary trie, err=%v", err)
+	}
+
+}
+
+func TestBinaryLeafInsertRead(t *testing.T) {
+	trie, err := NewBinary(NewDatabase(memorydb.New()))
+	if err != nil {
+		t.Fatalf("error creating binary trie: %v", err)
+	}
+
+	err = trie.TryUpdate(common.FromHex("00"), common.FromHex("01"))
+	if err != nil {
+		t.Fatalf("could not insert (0x00, 0x01) into an empty binary trie, err=%v", err)
+	}
+
+	v, err := trie.TryGet(common.FromHex("00"))
+	if err != nil {
+		t.Fatalf("could not read data back from simple binary trie, err=%v", err)
+	}
+
+	if !bytes.Equal(v, common.FromHex("01")) {
+		t.Fatalf("Invalid value read from the binary trie: %s != %s", common.ToHex(v), "01")
+	}
+}
+
+func TestBinaryForkInsertRead(t *testing.T) {
+	trie, err := NewBinary(NewDatabase(memorydb.New()))
+	if err != nil {
+		t.Fatalf("error creating binary trie: %v", err)
+	}
+
+	for i := byte(0); i < 10; i++ {
+		err = trie.TryUpdate([]byte{i}, common.FromHex("01"))
+		if err != nil {
+			t.Fatalf("could not insert (%#x, 0x01) into an empty binary trie, err=%v", i, err)
+		}
+	}
+
+	for i := byte(0); i < 10; i++ {
+		v, err := trie.TryGet([]byte{i})
+		if err != nil {
+			t.Fatalf("could not read data back from simple binary trie, err=%v", err)
+		}
+
+		if !bytes.Equal(v, common.FromHex("01")) {
+			t.Fatalf("Invalid value read from the binary trie: %s != %s", common.ToHex(v), "01")
+		}
+	}
+
+}

--- a/trie/binary_test.go
+++ b/trie/binary_test.go
@@ -90,6 +90,28 @@ func TestBinaryReadPrefix(t *testing.T) {
 	if !bytes.Equal(res, []byte("baguette")) {
 		t.Fatalf("should not have returned err=%v", err)
 	}
+
+	// Same test as above but the break is the last byte
+	// of the boundary
+	trieExtLeaf = &BinaryTrie{
+		prefix:   []byte("crois"),
+		startBit: 0,
+		endBit:   8*len("crois") - 1,
+		right: &BinaryTrie{
+			prefix:   []byte("ssants"),
+			startBit: 8,
+			endBit:   8 * len("ssants"),
+			value:    []byte("baguette"),
+			left:     nil,
+			right:    nil,
+		},
+		left: nil,
+	}
+
+	res, err = trieExtLeaf.TryGet([]byte("croissants"))
+	if !bytes.Equal(res, []byte("baguette")) {
+		t.Fatalf("should not have returned err=%v", err)
+	}
 }
 
 func TestBinaryLeafInsert(t *testing.T) {

--- a/trie/binary_test.go
+++ b/trie/binary_test.go
@@ -24,12 +24,9 @@ import (
 )
 
 func TestBinaryLeafReadEmpty(t *testing.T) {
-	trie, err := NewBinary(nil)
-	if err != nil {
-		t.Fatalf("error creating binary trie: %v", err)
-	}
+	trie := new(BinaryTrie)
 
-	_, err = trie.TryGet(common.FromHex("00"))
+	_, err := trie.TryGet(common.FromHex("00"))
 	if err == nil {
 		t.Fatalf("should have returned an error trying to get from an empty binry trie, err=%v", err)
 	}
@@ -115,12 +112,9 @@ func TestBinaryReadPrefix(t *testing.T) {
 }
 
 func TestBinaryLeafInsert(t *testing.T) {
-	trie, err := NewBinary(nil)
-	if err != nil {
-		t.Fatalf("error creating binary trie: %v", err)
-	}
+	trie := new(BinaryTrie)
 
-	err = trie.TryUpdate(common.FromHex("00"), common.FromHex("00"))
+	err := trie.TryUpdate(common.FromHex("00"), common.FromHex("00"))
 	if err != nil {
 		t.Fatalf("could not insert (0x00, 0x00) into an empty binary trie, err=%v", err)
 	}
@@ -128,12 +122,9 @@ func TestBinaryLeafInsert(t *testing.T) {
 }
 
 func TestBinaryLeafInsertRead(t *testing.T) {
-	trie, err := NewBinary(nil)
-	if err != nil {
-		t.Fatalf("error creating binary trie: %v", err)
-	}
+	trie := new(BinaryTrie)
 
-	err = trie.TryUpdate(common.FromHex("00"), common.FromHex("01"))
+	err := trie.TryUpdate(common.FromHex("00"), common.FromHex("01"))
 	if err != nil {
 		t.Fatalf("could not insert (0x00, 0x01) into an empty binary trie, err=%v", err)
 	}
@@ -149,13 +140,10 @@ func TestBinaryLeafInsertRead(t *testing.T) {
 }
 
 func TestBinaryForkInsertRead(t *testing.T) {
-	trie, err := NewBinary(nil)
-	if err != nil {
-		t.Fatalf("error creating binary trie: %v", err)
-	}
+	trie := new(BinaryTrie)
 
 	for i := byte(0); i <= 10; i++ {
-		err = trie.insert(0, []byte{i}, common.FromHex("01"), false)
+		err := trie.insert(0, []byte{i}, common.FromHex("01"), false)
 		if err != nil {
 			t.Fatalf("could not insert (%#x, 0x01) into an empty binary trie, err=%v", i, err)
 		}
@@ -173,11 +161,7 @@ func TestBinaryForkInsertRead(t *testing.T) {
 }
 
 func TestBinaryInsertLeftRight(t *testing.T) {
-	trie, err := NewBinary(nil)
-	if err != nil {
-		t.Fatalf("error creating binary trie: %v", err)
-	}
-
+	trie := new(BinaryTrie)
 	trie.TryUpdate([]byte{0}, []byte{0})
 	trie.TryUpdate([]byte{128}, []byte{1})
 

--- a/trie/binary_test.go
+++ b/trie/binary_test.go
@@ -21,11 +21,10 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 )
 
 func TestBinaryLeafReadEmpty(t *testing.T) {
-	trie, err := NewBinary(NewDatabase(memorydb.New()))
+	trie, err := NewBinary(nil)
 	if err != nil {
 		t.Fatalf("error creating binary trie: %v", err)
 	}
@@ -37,7 +36,7 @@ func TestBinaryLeafReadEmpty(t *testing.T) {
 }
 
 func TestBinaryLeafInsert(t *testing.T) {
-	trie, err := NewBinary(NewDatabase(memorydb.New()))
+	trie, err := NewBinary(nil)
 	if err != nil {
 		t.Fatalf("error creating binary trie: %v", err)
 	}
@@ -50,7 +49,7 @@ func TestBinaryLeafInsert(t *testing.T) {
 }
 
 func TestBinaryLeafInsertRead(t *testing.T) {
-	trie, err := NewBinary(NewDatabase(memorydb.New()))
+	trie, err := NewBinary(nil)
 	if err != nil {
 		t.Fatalf("error creating binary trie: %v", err)
 	}
@@ -71,7 +70,7 @@ func TestBinaryLeafInsertRead(t *testing.T) {
 }
 
 func TestBinaryForkInsertRead(t *testing.T) {
-	trie, err := NewBinary(NewDatabase(memorydb.New()))
+	trie, err := NewBinary(nil)
 	if err != nil {
 		t.Fatalf("error creating binary trie: %v", err)
 	}


### PR DESCRIPTION
Quick and Dirty prototype to build a binary trie from the snapshot, aimed at producing initial data for [1]. It doesn't do any caching, it doesn't do any parallelism, doesn't try to save memory and it stores branches very inefficiently.

@holiman it's also based on a pre-rebase version of `trie_gen`, I'll rebase if it helps/makes sense.

### Refs
 1. https://ethresear.ch/t/overlay-method-for-hex-bin-tree-conversion/7104/3

### TODO

 - [x] rebase
 - [x] pruning
 - [x] extensions
 - [x] parallelize generation and db writes
 - [x] rework storage format
 - [x] benchmark tests

### Running

This adds a `bintrie` subcommand to `geth` that takes the current snapshot and performs the conversion based on that, so conversion can be started with:

```
geth --snapshot bintrie
```