### PR TITLE
hash trie nodes with size < 32 bytes

### DIFF
--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -38,16 +38,16 @@ type ReStackTrie struct {
 // NewReStackTrie allocates and initializes an empty trie.
 func NewReStackTrie() *ReStackTrie {
 	return &ReStackTrie{
-		nodeType: 3,
+		nodeType: emptyNode,
 	}
 }
 
 // List all values that ReStackTrie#nodeType can hold
 const (
-	branchNode = iota
+	emptyNode = iota
+	branchNode
 	extNode
 	leafNode
-	emptyNode
 	hashedNode
 )
 

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -263,7 +263,8 @@ func rawExtHPRLP(key, val []byte) []byte {
 	// in that case `pos` wasn't incremented.
 	pos += (len(key) + oddkeylength) / 2
 
-	// Copy the value
+	// Copy the value, no need for a header because the child is
+	// already RLP and directly embedded.
 	copy(rlp[pos:], val)
 
 	// RLP header
@@ -348,7 +349,7 @@ func rawLeafHPRLP(key, val []byte, leaf bool) []byte {
 	// lower than 128, also add the header.
 	if len(val) > 1 || val[0] >= 128 {
 		payload[pos] = byte(len(val))
-		if len(val) > 1 {
+		if len(val) > 1 || val[0] > 128 {
 			payload[pos] += 128
 		}
 		pos += 1

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -60,6 +60,7 @@ type smallRLPTrie []struct {
 }
 
 var smallRLPTests = []smallRLPTrie{
+	// One leaf will have a size > 32, the other not.
 	smallRLPTrie{
 		{
 			"2ba639a09a19480b3290299aa982d38c688871e70b0734ac8aa69b9d59492fb3",
@@ -70,6 +71,7 @@ var smallRLPTests = []smallRLPTrie{
 			"a03330333335343331333033613332333333613330333732653330333033303561",
 		},
 	},
+	// Both leaves have sizes smaller than 32.
 	smallRLPTrie{
 		{
 			"2ba639a09a19480b3290299aa982d38c688871e70b0734ac8aa69b9d59492fb3",
@@ -78,6 +80,20 @@ var smallRLPTests = []smallRLPTrie{
 		{
 			"2ba639a09acf0edbf01831ef3366124dece00d7e4c498f46126d214a8bca7436",
 			"a033",
+		},
+	},
+	// Only one leaf
+	smallRLPTrie{
+		{
+			"2ba639a09a19480b3290299aa982d38c688871e70b0734ac8aa69b9d59492fb3",
+			"8181",
+		},
+	},
+	// Leaf with an odd-length value and a size < 32
+	smallRLPTrie{
+		{
+			"2ba639a09a19480b3290299aa982d38c688871e70b0734ac8aa69b9d59492fb3",
+			"81",
 		},
 	},
 }

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -18,7 +18,6 @@ package trie
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -1,0 +1,54 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestRawHPRLP(t *testing.T) {
+	got := rawHPRLP([]byte{0x00, 0x01}, []byte{0x02, 0x03}, true)
+	exp := []byte{6, 2, 32, 1, 2, 2, 3}
+
+	if !bytes.Equal(exp, got) {
+		t.Fatalf("invalid RLP generated for leaf with even length key: got %v, expected %v", common.ToHex(got), common.ToHex(exp))
+	}
+
+	got = rawHPRLP([]byte{0x01}, []byte{0x02, 0x03}, true)
+	exp = []byte{4, 49, 2, 2, 3}
+
+	if !bytes.Equal(exp, got) {
+		t.Fatalf("invalid RLP generated for leaf with odd length key: got %v, expected %v", common.ToHex(got), common.ToHex(exp))
+	}
+
+	got = rawHPRLP([]byte{0x00, 0x01}, []byte{0x02, 0x03}, false)
+	exp = []byte{6, 2, 0, 1, 2, 2, 3}
+
+	if !bytes.Equal(exp, got) {
+		t.Fatalf("invalid RLP generated for ext with even length key: got %v, expected %v", common.ToHex(got), common.ToHex(exp))
+	}
+
+	got = rawHPRLP([]byte{0x01}, []byte{0x02, 0x03}, false)
+	exp = []byte{4, 17, 2, 2, 3}
+
+	if !bytes.Equal(exp, got) {
+		t.Fatalf("invalid RLP generated for ext with odd length key: got %v, expected %v", common.ToHex(got), common.ToHex(exp))
+	}
+}

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -96,6 +96,18 @@ var smallRLPTests = []smallRLPTrie{
 			"81",
 		},
 	},
+	// Two leaves whose size is < 32 and one of them has a one-byte value
+	// bigger than 128.
+	smallRLPTrie{
+		{
+			"2ba639a09a19480b3290299aa982d38c688871e70b0734ac8aa69b9d59492fb3",
+			"8181",
+		},
+		{
+			"2ba639a09acf0edbf01831ef3366124dece00d7e4c498f46126d214a8bca7436",
+			"a0",
+		},
+	},
 }
 
 func TestHashWithSmallRLP(t *testing.T) {

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -18,6 +18,7 @@ package trie
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -66,6 +67,7 @@ func TestHashWithSmallRLP(t *testing.T) {
 	d := sha3.NewLegacyKeccak256()
 	d.Write(trie.hash())
 	got := d.Sum(nil)
+	fmt.Println(got)
 	exp := aotrie.Hash()
 
 	if !bytes.Equal(got, exp[:]) {


### PR DESCRIPTION
This PR introduces two helper functions to be called when the size of the RLP of a hashed child node is less than 32 bytes.