### PR TITLE
Speedtests: fix slot writes

### DIFF
--- a/cmd/geth/converkle.go
+++ b/cmd/geth/converkle.go
@@ -142,9 +142,11 @@ type slotHash struct {
 func iterateSlots(slotCh chan *slotHash, storageIt snapshot.StorageIterator) {
 	defer storageIt.Release()
 	for storageIt.Next() {
+		var slot [32]byte
+		copy(slot[:], storageIt.Slot())
 		slotCh <- &slotHash{
 			hash: storageIt.Hash(),
-			slot: storageIt.Slot(),
+			slot: slot[:],
 		}
 	}
 	if storageIt.Error() != nil {


### PR DESCRIPTION
The copy of the output of `Slot()` solves the problem in which two runs of `to-verkle` would see some leaves being different from one run to the next. I assume that the problem is that `Slot()` returns a buffer that is reused.