### PR TITLE
use little endian pedersen_hash output to compute key

### DIFF
--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -70,7 +70,17 @@ func GetTreeKey(address []byte, treeIndex *uint256.Int, subIndex byte) []byte {
 
 	cfg, _ := verkle.GetConfig()
 	ret := cfg.CommitToPoly(poly[:], 0)
-	retb := ret.Bytes()
+
+	// The output of Byte() is big engian for banderwagon. This
+	// introduces an inbalance in the tree, because hashes are
+	// elements of a 253-bit field. This means more than half the
+	// tree would be empty. To avoid this problem, use a little
+	// endian commitment and chop the MSB.
+	var retb [32]byte
+	retb = ret.Bytes()
+	for i := 0; i < 16; i++ {
+		retb[31-i], retb[i] = retb[i], retb[31-i]
+	}
 	retb[31] = subIndex
 	return retb[:]
 


### PR DESCRIPTION
This fix is due to a change in endianness of the underlying curve: Banderwagon currently returns big endian bytes when calling `Bytes()`, which Bandersnatch didn't.

This creates a problem, because the field is 253 bits, so the most significant byte isn't fully used. That means stems will always have their first byte in the [0..0x73] range, and so the tree will be unbalanced.

This PR forces the use of little-endian in `get_tree_key` so that this problem doesn't happen.