### PR TITLE
core/vm: remove unnecessary check

### DIFF
--- a/cmd/eofdump/testdata/results.initcode.txt
+++ b/cmd/eofdump/testdata/results.initcode.txt
@@ -1906,7 +1906,7 @@ ERR: unreachable code: arg 253, last 1, pos 13
 ERR: invalid magic: want ef00 in sub container 0
 ERR: missing data header: found section fe instead in sub container 0
 ERR: invalid type content, max stack height exceeds limit for section 0: have 65007 in sub container 0
-ERR: section already referenced, arg :0
+ERR: stack underflow (0 <=> 4): at pos 0
 ERR: subcontainer not referenced at all
 ERR: truncated immediate: op PUSH20, pos 6
 ERR: invalid jump destination: out-of-bounds offset: offset 12336, dest 12342, pos 4

--- a/cmd/eofdump/testdata/results.regular.txt
+++ b/cmd/eofdump/testdata/results.regular.txt
@@ -1906,14 +1906,14 @@ ERR: unreachable code: arg 253, last 1, pos 13
 ERR: invalid container size: have 24594, want 24591
 ERR: missing data header: found section fe instead in sub container 0
 ERR: invalid type content, max stack height exceeds limit for section 0: have 65007 in sub container 0
-ERR: section already referenced, arg :0
+ERR: stack underflow (0 <=> 4): at pos 0
 ERR: subcontainer not referenced at all
 ERR: truncated immediate: op PUSH20, pos 6
 ERR: invalid jump destination: out-of-bounds offset: offset 12336, dest 12342, pos 4
 ERR: invalid backward jump want 4 as current min got 5 at pos 12,
 ERR: invalid backward jump want 0 as current min got 1 at pos 12,
 ERR: unreachable code: arg 48, last 1, pos 13
-ERR: section already referenced, arg :0
+ERR: invalid code termination: end with ADDRESS, pos 17
 ERR: unreachable code: arg 48, last 2, pos 8
 ERR: invalid code termination: end with ADDRESS, pos 1
 ERR: invalid section argument: arg 12336, last 1, pos 14

--- a/core/vm/eof.go
+++ b/core/vm/eof.go
@@ -127,10 +127,15 @@ func (c *Container) MarshalBinary() []byte {
 
 // UnmarshalBinary decodes an EOF container.
 func (c *Container) UnmarshalBinary(b []byte, isInitcode bool) error {
-	return c.unmarshalSubContainer(b, isInitcode, true)
+	return c.unmarshalContainer(b, isInitcode, true)
 }
 
-func (c *Container) unmarshalSubContainer(b []byte, isInitcode bool, topLevel bool) error {
+// UnmarshalSubContainer decodes an EOF container that is inside another container.
+func (c *Container) UnmarshalSubContainer(b []byte, isInitcode bool) error {
+	return c.unmarshalContainer(b, isInitcode, false)
+}
+
+func (c *Container) unmarshalContainer(b []byte, isInitcode bool, topLevel bool) error {
 	if !hasEOFMagic(b) {
 		return fmt.Errorf("%w: want %x", ErrInvalidMagic, eofMagic)
 	}
@@ -275,7 +280,7 @@ func (c *Container) unmarshalSubContainer(b []byte, isInitcode bool, topLevel bo
 			}
 			subC := new(Container)
 			end := min(idx+size, len(b))
-			if err := subC.unmarshalSubContainer(b[idx:end], isInitcode, false); err != nil {
+			if err := subC.unmarshalContainer(b[idx:end], isInitcode, false); err != nil {
 				if topLevel {
 					return fmt.Errorf("%w in sub container %d", err, i)
 				}

--- a/core/vm/validate.go
+++ b/core/vm/validate.go
@@ -182,9 +182,6 @@ func validateCode(code []byte, section int, container *Container, jt *JumpTable,
 			if visitedSubcontainers == nil {
 				visitedSubcontainers = make(map[int]int)
 			}
-			if _, ok := visitedSubcontainers[arg]; ok {
-				return nil, fmt.Errorf("section already referenced, arg :%d", arg)
-			}
 			// We need to store per subcontainer how it was referenced
 			if v, ok := visitedSubcontainers[arg]; ok && v != refByEOFCreate {
 				return nil, fmt.Errorf("section already referenced, arg :%d", arg)


### PR DESCRIPTION
This PR removes an unnecessary check, however it seems like we don't have a test for it yet that shows that the behavior of EOFCREATE referencing the same subcontainer twice is actually permissible. I will try to add that to the spec tests