### PR TITLE
optimize eof jumpdest analysis

### DIFF
--- a/core/asm/asm_test.go
+++ b/core/asm/asm_test.go
@@ -34,6 +34,7 @@ func TestInstructionIterator(t *testing.T) {
 		{2, "5900", ""},                            // push0
 		{0, "", ""},                                // empty
 		{2, "d1aabb00", ""},                        // DATALOADN(aabb),STOP
+		{0, "d1aa", "incomplete instruction at 0"}, // DATALOADN(aa) invalid
 
 	} {
 		var (

--- a/core/vm/analysis_eof.go
+++ b/core/vm/analysis_eof.go
@@ -35,14 +35,7 @@ func eofCodeBitmapInternal(code, bits bitvec) bitvec {
 		)
 		pc++
 
-		switch {
-		case op < PUSH1:
-			continue
-		case op <= PUSH32:
-			numbits = uint16(op - PUSH1 + 1)
-		case op == RJUMP || op == RJUMPI || op == CALLF || op == JUMPF || op == DATALOADN:
-			numbits = 2
-		case op == RJUMPV:
+		if op == RJUMPV {
 			// RJUMPV is unique as it has a variable sized operand.
 			// The total size is determined by the count byte which
 			// immediate proceeds RJUMPV. Truncation will be caught
@@ -60,11 +53,11 @@ func eofCodeBitmapInternal(code, bits bitvec) bitvec {
 				// as possible.
 				numbits = uint16(end - pc)
 			}
-		case op == DUPN || op == SWAPN || op == EXCHANGE || op == EOFCREATE || op == RETURNCONTRACT:
-			numbits = 1
-		default:
-			// Op had no immediate operand, continue.
-			continue
+		} else {
+			numbits = uint16(Immediates(op))
+			if numbits == 0 {
+				continue
+			}
 		}
 
 		if numbits >= 8 {

--- a/core/vm/analysis_legacy_test.go
+++ b/core/vm/analysis_legacy_test.go
@@ -130,4 +130,6 @@ func BenchmarkJumpdestOpEOFAnalysis(bench *testing.B) {
 	bench.Run(op.String(), bencher)
 	op = RJUMPV
 	bench.Run(op.String(), bencher)
+	op = EOFCREATE
+	bench.Run(op.String(), bencher)
 }

--- a/core/vm/analysis_legacy_test.go
+++ b/core/vm/analysis_legacy_test.go
@@ -105,3 +105,29 @@ func BenchmarkJumpdestOpAnalysis(bench *testing.B) {
 	op = STOP
 	bench.Run(op.String(), bencher)
 }
+
+func BenchmarkJumpdestOpEOFAnalysis(bench *testing.B) {
+	var op OpCode
+	bencher := func(b *testing.B) {
+		code := make([]byte, analysisCodeSize)
+		b.SetBytes(analysisCodeSize)
+		for i := range code {
+			code[i] = byte(op)
+		}
+		bits := make(bitvec, len(code)/8+1+4)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			clear(bits)
+			eofCodeBitmapInternal(code, bits)
+		}
+	}
+	for op = PUSH1; op <= PUSH32; op++ {
+		bench.Run(op.String(), bencher)
+	}
+	op = JUMPDEST
+	bench.Run(op.String(), bencher)
+	op = STOP
+	bench.Run(op.String(), bencher)
+	op = RJUMPV
+	bench.Run(op.String(), bencher)
+}


### PR DESCRIPTION
Rewrites the EOF jumpdest analysis to use the new intermediate map.
This will improve the worst case by ~2x

```
Master:
BenchmarkJumpdestOpEOFAnalysis/PUSH1-24         	    1534	    775426 ns/op	1584.68 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH2-24         	    1659	    720090 ns/op	1706.45 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH3-24         	    2150	    560181 ns/op	2193.58 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH4-24         	    2806	    439871 ns/op	2793.55 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH5-24         	    3283	    358106 ns/op	3431.39 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH6-24         	    3267	    321608 ns/op	3820.81 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH7-24         	    3824	    298297 ns/op	4119.38 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH8-24         	    3319	    351931 ns/op	3491.59 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH9-24         	    3981	    299650 ns/op	4100.79 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH10-24        	    3555	    346088 ns/op	3550.55 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH11-24        	    3804	    312505 ns/op	3932.10 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH12-24        	    4126	    292700 ns/op	4198.16 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH13-24        	    4399	    271994 ns/op	4517.74 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH14-24        	    4402	    268524 ns/op	4576.13 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH15-24        	    4638	    255355 ns/op	4812.13 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH16-24        	    6836	    178987 ns/op	6865.32 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH17-24        	    7131	    168099 ns/op	7309.96 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH18-24        	    6255	    188319 ns/op	6525.11 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH19-24        	    6630	    180211 ns/op	6818.66 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH20-24        	    6696	    178263 ns/op	6893.18 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH21-24        	    7234	    165523 ns/op	7423.75 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH22-24        	    6954	    164039 ns/op	7490.91 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH23-24        	    7604	    160611 ns/op	7650.81 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH24-24        	    8128	    154231 ns/op	7967.29 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH25-24        	    7567	    161778 ns/op	7595.62 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH26-24        	    7218	    167406 ns/op	7340.23 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH27-24        	    7346	    164531 ns/op	7468.52 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH28-24        	    7318	    165444 ns/op	7427.28 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH29-24        	    7779	    153889 ns/op	7984.98 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH30-24        	    7881	    145334 ns/op	8454.99 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH31-24        	    8082	    147841 ns/op	8311.62 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH32-24        	    9270	    128299 ns/op	9577.63 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/JUMPDEST-24      	    4304	    265604 ns/op	4626.43 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/STOP-24          	    4363	    260641 ns/op	4714.53 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/RJUMPV-24        	   13783	     85806 ns/op	14320.64 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/EOFCREATE-24     	     724	   1471215 ns/op	 835.23 MB/s	       0 B/op	       0 allocs/op
```

```
This PR
BenchmarkJumpdestOpEOFAnalysis/PUSH1-24         	    1712	    696629 ns/op	1763.92 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH2-24         	    1916	    645600 ns/op	1903.34 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH3-24         	    2190	    546215 ns/op	2249.66 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH4-24         	    3384	    350009 ns/op	3510.77 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH5-24         	    3974	    295326 ns/op	4160.83 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH6-24         	    3810	    311755 ns/op	3941.56 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH7-24         	    4395	    272460 ns/op	4510.02 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH8-24         	    3092	    340062 ns/op	3613.46 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH9-24         	    3987	    300484 ns/op	4089.40 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH10-24        	    3726	    321061 ns/op	3827.30 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH11-24        	    3757	    322260 ns/op	3813.07 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH12-24        	    4456	    272634 ns/op	4507.14 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH13-24        	    4754	    252932 ns/op	4858.23 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH14-24        	    3943	    264757 ns/op	4641.24 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH15-24        	    4597	    260192 ns/op	4722.67 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH16-24        	    6721	    177583 ns/op	6919.60 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH17-24        	    7161	    170342 ns/op	7213.73 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH18-24        	    6780	    182602 ns/op	6729.39 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH19-24        	    6140	    196087 ns/op	6266.60 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH20-24        	    6980	    174430 ns/op	7044.65 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH21-24        	    7480	    158205 ns/op	7767.12 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH22-24        	    6961	    168630 ns/op	7286.96 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH23-24        	    7238	    158811 ns/op	7737.51 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH24-24        	    7744	    158755 ns/op	7740.23 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH25-24        	    7362	    159182 ns/op	7719.47 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH26-24        	    7436	    157651 ns/op	7794.43 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH27-24        	    7598	    155116 ns/op	7921.79 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH28-24        	    7693	    164896 ns/op	7451.98 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH29-24        	    7726	    150801 ns/op	8148.49 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH30-24        	    8032	    156206 ns/op	7866.53 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH31-24        	    8281	    151258 ns/op	8123.89 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/PUSH32-24        	    9327	    129709 ns/op	9473.49 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/JUMPDEST-24      	    2211	    554137 ns/op	2217.50 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/STOP-24          	    2151	    540229 ns/op	2274.59 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/RJUMPV-24        	   14330	     81301 ns/op	15114.17 MB/s	       0 B/op	       0 allocs/op
BenchmarkJumpdestOpEOFAnalysis/EOFCREATE-24     	    1710	    693609 ns/op	1771.60 MB/s	       0 B/op	       0 allocs/op
```